### PR TITLE
Fix compression date preservation for Android 10+ (API 29+)

### DIFF
--- a/android/app/src/main/com/voicelike/app/ImageCompressionView.kt
+++ b/android/app/src/main/com/voicelike/app/ImageCompressionView.kt
@@ -987,6 +987,10 @@ private suspend fun saveCompressedImage(
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         val pendingValues = ContentValues().apply {
             put(MediaStore.Images.Media.IS_PENDING, 0)
+            if (originalDateAdded > 0) {
+                put(MediaStore.Images.Media.DATE_ADDED, originalDateAdded)
+                put(MediaStore.Images.Media.DATE_MODIFIED, originalDateAdded)
+            }
         }
         resolver.update(uri, pendingValues, null, null)
     }

--- a/android/app/src/main/com/voicelike/app/VideoCompressionView.kt
+++ b/android/app/src/main/com/voicelike/app/VideoCompressionView.kt
@@ -977,6 +977,10 @@ private suspend fun saveCompressedVideo(
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         val pendingValues = ContentValues().apply {
             put(MediaStore.Video.Media.IS_PENDING, 0)
+            if (originalDateAdded > 0) {
+                put(MediaStore.Video.Media.DATE_ADDED, originalDateAdded)
+                put(MediaStore.Video.Media.DATE_MODIFIED, originalDateAdded)
+            }
         }
         resolver.update(uri, pendingValues, null, null)
     }


### PR DESCRIPTION
Issue: When I compress media, they show up at the top of my gallery - they get the current date. When in reality they should get the original date of the media.

Usually when I compress multiple media in batches, I find all of them at the top of my gallery clustered up.

Modified saveCompressedImage() and saveCompressedVideo() to preserve original DATE_ADDED and DATE_MODIFIED timestamps during the IS_PENDING transition update, which works correctly on API 29+ where insert-time timestamp setting is ignored.